### PR TITLE
adding babel-preset-react and babel-preset-stage-0 as dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+.idea/

--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
   "devDependencies": {
     "babel-core": "^6.23.1",
     "babel-loader": "^6.4.0",
-    "babel-preset-react": "^6.23.0",
-    "babel-preset-stage-0": "^6.22.0",
     "webpack": "^2.2.1"
+  },
+  "dependencies": {
+    "babel-preset-react": "^6.23.0",
+    "babel-preset-stage-0": "^6.22.0"
   },
   "peerDependencies": {
     "react": "^15.4.2"


### PR DESCRIPTION
This fixes an issue when using react-redux-mock with npm.

Because `babel-preset-react` and `babel-preset-stage-0` was added as a devDependencies they were not installed in the node-modules folder. Therefore this results in a babel preset error when running test. The reason for this error is because `babel-preset-react` and `babel-preset-stage-0` are missing.

**Error Details**
ReferenceError: [BABEL] /node_modules/react-redux-mock/lib/index.js: Unknown option: /node_modules/react/index.js.Children. Check out http://babeljs.io/docs/usage/options/ for more informa
tion about options.                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                            
    A common cause of this error is the presence of a configuration options object without the corresponding preset name. Example:                                                                                                                                          
                                                                                                                                                                                                                                                                            
    Invalid:                                                                                                                                                                                                                                                                
      `{ presets: [{option: value}] }`                                                                                                                                                                                                                                      
    Valid:                                                                                                                                                                                                                                                                  
      `{ presets: [['presetName', {option: value}]] }`                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                            
    For more detailed information on preset configuration, please see http://babeljs.io/docs/plugins/#pluginpresets-options.